### PR TITLE
Features: add dummy ping endpoint for lb health check

### DIFF
--- a/flower/__init__.py
+++ b/flower/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 
-VERSION = (1, 0, 0)
+VERSION = (1, 1, 0)
 __version__ = '.'.join(map(str, VERSION)) + '-dev'

--- a/flower/urls.py
+++ b/flower/urls.py
@@ -15,6 +15,7 @@ from .views.workers import WorkerView
 from .views.tasks import TaskView, TasksView, TasksDataTable
 from .views.error import NotFoundErrorHandler
 from .views.dashboard import DashboardView, DashboardUpdateHandler
+from .views.ping import PingView
 from .utils import gen_cookie_secret
 
 
@@ -29,6 +30,7 @@ settings = dict(
 
 handlers = [
     # App
+    url(r"/ping", PingView, name='ping'),
     url(r"/", DashboardView, name='main'),
     url(r"/dashboard", DashboardView, name='dashboard'),
     url(r"/worker/(.+)", WorkerView, name='worker'),


### PR DESCRIPTION
Le loadbalancer de GCP a besoin d'un endpoint accessible sans authentification pour s'assurer que le service est bien disponible.

Cette PR ajoute un endpoint un peu simple sur /ping qui n'utilise pas l'authentification comme toutes les autres vues.