### PR TITLE
DATA-471: fix max result size & timeout when retrieving tasks

### DIFF
--- a/flower/__init__.py
+++ b/flower/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 
-VERSION = (1, 2, 0)
+VERSION = (1, 2, 1)
 __version__ = '.'.join(map(str, VERSION)) + '-dev'

--- a/flower/views/tasks.py
+++ b/flower/views/tasks.py
@@ -113,7 +113,7 @@ class TasksDataTable(BaseHandler):
             task_dict['args'] = task_dict['args'][:25] + '...' if len(task_dict['args']) > 25 else task_dict['args']
             task_dict['kwargs'] = task_dict['kwargs'][:25] + '...' if len(task_dict['kwargs']) > 25 else task_dict['kwargs']
 
-        q = N1QLQuery('select count(uuid) AS total_doc from `{bucket_name}`'.format(
+        q = N1QLQuery('select count(*) AS total_doc from `{bucket_name}`'.format(
             bucket_name=self.application.options.state_backend_bucket_name
         ))
         total_doc_count = [r for r in self.bucket.n1ql_query(q)][0]['total_doc']
@@ -121,7 +121,7 @@ class TasksDataTable(BaseHandler):
 
         filtered_tasks = []
         if search:
-            task_count = len([r['id'] for r in self.bucket.search(self.application.options.state_backend_fts_name, FT.TermQuery(search), limit=recordsTotal)])
+            task_count = len([r['id'] for r in self.bucket.search(self.application.options.state_backend_fts_name, FT.TermQuery(search), limit=length)])
             task_ids = [r['id'] for r in self.bucket.search(self.application.options.state_backend_fts_name, FT.TermQuery(search), limit=length, skip=start)]
             recordsFiltered = task_count
             if task_ids:


### PR DESCRIPTION
-  le count(*) permet d'utiliser l'index primaire directement (donc simple peine ou lieu de la double) ;
- limiter sur le bon nombre de documents lors de la recherche fulltext, c'est quand même moins mongole ;
- ça ne résout pas le soucis du tri lorsqu'il y a trop de document (> 100k, soucis), je le laisse quand même car c'est très pratique, on espère garder un stock d'erreurs limité pour que l'interface reste utilisable.