### PR TITLE
Fixes: freeze tornado version

### DIFF
--- a/flower/__init__.py
+++ b/flower/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 
-VERSION = (1, 2, 1)
+VERSION = (1, 2, 2)
 __version__ = '.'.join(map(str, VERSION)) + '-dev'

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 celery>=3.1.0
 couchbase
-tornado>=4.2.0
+tornado>=4.2.0,<6.0
 babel>=1.0
 pytz
 redis


### PR DESCRIPTION
car le tornado >= 6.0 n'est pas compatible avec du python 3.4 que l'on a partout !